### PR TITLE
Poof: add some hover jiggle to the 🎧 tile

### DIFF
--- a/style.css
+++ b/style.css
@@ -117,3 +117,9 @@ h1 {
 .jiggle {
   animation: jiggle 0.3s infinite;
 } 
+
+/*jiggle animation for the 🎧 tile when clicked or hovered */
+.jiggle,
+#play-music:hover {
+  animation: jiggle 0.3s infinite;
+} 


### PR DESCRIPTION
**Overview**
So, in my last merge I kinda missed that the headphone tile didn’t jiggle on hover — only on click. This PR fixes that little oversight by adding the jiggle on hover too, making the music vibes way more alive and interactive. Just giving pixel-poof that extra poof it deserves. 🎧

**How to test**
_Current behavior:_
- Clicking the 🎧 tile plays music but the tile only jiggles on click, stopping once the mouse moves away.
- Hovering over the tile doesn’t cause any jiggle.

_Expected behavior after this change:_
- Clicking the 🎧 tile plays music and starts the jiggle animation.
- Hovering over the tile keeps the jiggle going even if the music isn’t playing.
- Jiggle stops only when the music ends and the mouse is no longer hovering.
- Motorcycle click still works normally, updating miles and playing the vroom sound.

**Other notes:**
1. CSS animation is lightweight and shouldn’t affect performance.
2. This update currently applies only to the headphone tile — other tiles will get their own animations later,
3. Tested on Chrome — if anyone tries other browsers, 🤷‍♂️